### PR TITLE
[feat] FileService의 convertContentTypeToMediaType(String)메서드 수정

### DIFF
--- a/src/main/java/applesquare/moment/file/service/FileService.java
+++ b/src/main/java/applesquare/moment/file/service/FileService.java
@@ -41,7 +41,7 @@ public interface FileService {
      * @return MediaType 열거형
      */
     static MediaType convertContentTypeToMediaType(String contentType){
-        if(contentType==null) throw new IllegalArgumentException("contentType이 null입니다.");
+        if(contentType==null || contentType.isBlank()) throw new IllegalArgumentException("contentType이 비어있습니다.");
         if(contentType.startsWith(CONTENT_TYPE_IMAGE_PREFIX)) return MediaType.IMAGE;
         else if(contentType.startsWith(CONTENT_TYPE_VIDEO_PREFIX)) return MediaType.VIDEO;
         else throw new IllegalArgumentException("mediaType으로 변경할 수 없는 contentType입니다. (contentType="+contentType+")");


### PR DESCRIPTION
contentType이 빈 칸(blank)인 경우, null일 때와 마찬가지로 예외 처리합니다.