### PR TITLE
[feat] 카카오, 네이버 로그인 콜백 함수 수정

### DIFF
--- a/src/main/java/applesquare/moment/address/service/impl/KakaoAddressServiceImpl.java
+++ b/src/main/java/applesquare/moment/address/service/impl/KakaoAddressServiceImpl.java
@@ -20,8 +20,7 @@ public class KakaoAddressServiceImpl implements KakaoAddressService {
     private final RestTemplate restTemplate;
     @Value("${kakao.client.id}")
     private String kakaoClientId;
-    @Value("${kakao.address.url}")
-    private String kakaoAddressUrl;
+    private final String kakaoAddressUrl="https://dapi.kakao.com/v2/local/search/address.json";
 
 
     /**

--- a/src/main/java/applesquare/moment/config/SecurityConfig.java
+++ b/src/main/java/applesquare/moment/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import applesquare.moment.auth.service.TokenBlacklistService;
 import applesquare.moment.user.service.UserProfileService;
 import applesquare.moment.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,6 +46,8 @@ public class SecurityConfig {
     private final TokenBlacklistService tokenBlacklistService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    @Value("${moment.front.domain}")
+    private String momentFrontDomain;
 
 
     @Bean
@@ -58,7 +61,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource(){
         // 접근 허용할 도메인, 메서드, 헤더 설정
         CorsConfiguration configuration=new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("https://www.applesquare.click"));  // 프론트 서버 도메인
+        configuration.setAllowedOriginPatterns(Arrays.asList(momentFrontDomain));    // 프론트 서버 도메인
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setExposedHeaders(Arrays.asList("Authorization"));

--- a/src/main/java/applesquare/moment/location/service/impl/KakaoLocationServiceImpl.java
+++ b/src/main/java/applesquare/moment/location/service/impl/KakaoLocationServiceImpl.java
@@ -20,8 +20,7 @@ public class KakaoLocationServiceImpl implements KakaoLocationService {
     private final RestTemplate restTemplate;
     @Value("${kakao.client.id}")
     private String kakaoClientId;
-    @Value("${kakao.location.url}")
-    private String kakaoLocationUrl;
+    private final String kakaoLocationUrl="https://dapi.kakao.com/v2/local/search/keyword.json";
 
 
     /**

--- a/src/main/java/applesquare/moment/oauth/kakao/controller/KakaoOAuthController.java
+++ b/src/main/java/applesquare/moment/oauth/kakao/controller/KakaoOAuthController.java
@@ -1,7 +1,6 @@
 package applesquare.moment.oauth.kakao.controller;
 
 
-import applesquare.moment.common.exception.ResponseMap;
 import applesquare.moment.oauth.service.OAuthService;
 import applesquare.moment.user.dto.UserProfileReadResponseDTO;
 import applesquare.moment.util.JwtUtil;
@@ -16,9 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth/kakao")
@@ -31,68 +27,78 @@ public class KakaoOAuthController {
     private String kakaoClientId;
     @Value("${kakao.oauth.redirect-uri}")
     private String kakaoOauthRedirectUri;
-    @Value("${kakao.login.url}")
-    private String kakaoLoginUrl;
+    @Value("${moment.front.main.url}")
+    private String momentMainUrl;
+    @Value("${moment.front.error.500.url}")
+    private String moment500ErrorUrl;
+
+    private final String kakaoLoginUrl="https://kauth.kakao.com/oauth/authorize";
 
 
     /**
      * 카카오 로그인 API
-     * (카카오 로그인 화면으로 리다이렉트)
+     * (카카오 로그인 페이지 URL 전달)
      *
-     * @return  (status) 302,
-     *          (header) 카카오 로그인 URL
+     * @return  (status) 200,
+     *          (body) 카카오 로그인 URL
      */
     @GetMapping("/login")
-    public ResponseEntity<Void> redirectToKakaoAuth(){
-        // HTTP Header 생성
-        HttpHeaders headers=new HttpHeaders();
-
+    public ResponseEntity<String> redirectToKakaoAuth(){
         // 카카오 로그인 화면으로 리다이렉트
         String url = new StringBuilder(kakaoLoginUrl)
                 .append("?client_id=").append(kakaoClientId)
                 .append("&redirect_uri=").append(kakaoOauthRedirectUri)
                 .append("&response_type=code")
                 .toString();
-        headers.setLocation(URI.create(url));
 
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .headers(headers)
-                .build();
-    }
+        return ResponseEntity.status(HttpStatus.OK).body(url);
+   }
 
     /**
      * 카카오 로그인 콜백 API
      * (인가 코드를 받아 로그인 처리를 완료시킴)
      *
      * @param code 인가 코드
-     * @return  (status) 200,
-     *          (header) Access, Refresh 토큰
-     *          (body) 소셜 유저 정보
+     * @return  (status) 302,
+     *          (header > Authorization) Access 토큰
+     *          (header > Set-Cookie) Refresh 토큰
+     *          (header > Location) 성공한 경우 -> moment 메인 페이지 URL
+     *          (header > Location) 에러난 경우 -> moment 500 에러 페이지 URL
      */
     @GetMapping("/callback")
-    public ResponseEntity<Map<String, Object>> callback(@RequestParam String code){
-        // 유저 프로필 조회
-        UserProfileReadResponseDTO userProfileDTO=oAuthService.loginWithKakao(code);
+    public ResponseEntity<Void> callback(@RequestParam String code){
+        try{
+            // 유저 프로필 조회
+            UserProfileReadResponseDTO userProfileDTO=oAuthService.loginWithKakao(code);
 
-        // HTTP Header 설정
-        HttpHeaders headers=new HttpHeaders();
+            // HTTP Header 설정
+            HttpHeaders headers=new HttpHeaders();
 
-        // Access 토큰 발급
-        String userId= userProfileDTO.getId();
-        String accessToken = jwtUtil.generateAccessToken(userId);
-        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+            // Access 토큰 발급
+            String userId= userProfileDTO.getId();
+            String accessToken = jwtUtil.generateAccessToken(userId);
+            headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
 
-        // Refresh 토큰 발급
-        ResponseCookie refreshTokenCookie= jwtUtil.generateRefreshCookie(userId);
-        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+            // Refresh 토큰 발급
+            ResponseCookie refreshTokenCookie= jwtUtil.generateRefreshCookie(userId);
+            headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        // HTTP Body 설정
-        ResponseMap responseMap=new ResponseMap();
-        responseMap.put("message", "카카오 로그인에 성공했습니다.");
-        responseMap.put("user", userProfileDTO);
+            // Location 설정
+            headers.add(HttpHeaders.LOCATION, momentMainUrl);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .headers(headers)
-                .body(responseMap.getMap());
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .headers(headers)
+                    .build();
+        } catch (Exception e){
+            // 실패 했으면, 500 에러 페이지로 리다이렉트
+
+            // Location 설정
+            HttpHeaders headers=new HttpHeaders();
+            headers.add(HttpHeaders.LOCATION, moment500ErrorUrl);
+
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .headers(headers)
+                    .build();
+        }
     }
 }

--- a/src/main/java/applesquare/moment/oauth/kakao/service/impl/KakaoAuthServiceImpl.java
+++ b/src/main/java/applesquare/moment/oauth/kakao/service/impl/KakaoAuthServiceImpl.java
@@ -27,10 +27,8 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
     private String kakaoClientId;
     @Value("${kakao.oauth.redirect-uri}")
     private String kakaoOauthRedirectUri;
-    @Value("${kakao.token.url}")
-    private String kakaoTokenUrl;
-    @Value("${kakao.user.info.url}")
-    private String kakaoUserInfoUrl;
+    private final String kakaoTokenUrl="https://kauth.kakao.com/oauth/token";
+    private final String kakaoUserInfoUrl="https://kapi.kakao.com/v2/user/me";
 
 
     /**

--- a/src/main/java/applesquare/moment/oauth/naver/controller/NaverOAuthController.java
+++ b/src/main/java/applesquare/moment/oauth/naver/controller/NaverOAuthController.java
@@ -1,6 +1,5 @@
 package applesquare.moment.oauth.naver.controller;
 
-import applesquare.moment.common.exception.ResponseMap;
 import applesquare.moment.common.service.StateService;
 import applesquare.moment.oauth.service.OAuthService;
 import applesquare.moment.user.dto.UserProfileReadResponseDTO;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -38,23 +36,26 @@ public class NaverOAuthController{
     // 네이버 로그인 환경 변수
     @Value("${naver.client.id}")
     private String naverClientId;
-    @Value("${naver.login.url}")
-    private String naverLoginUrl;
     @Value("${naver.oauth.redirect-uri}")
     private String naverOauthRedirectUri;
+    @Value("${moment.front.main.url}")
+    private String momentMainUrl;
+    @Value("${moment.front.error.500.url}")
+    private String moment500ErrorUrl;
 
+    private final String naverLoginUrl="https://nid.naver.com/oauth2.0/authorize";
     private final String NAVER_STATE_METADATA="naver-login-redirect";
 
 
     /**
      * 네이버 로그인 API
-     * (네이버 로그인 화면으로 리다이렉트)
+     * (네이버 로그인 페이지 URL 전달)
      *
-     * @return  (status) 302,
-     *          (header) 네이버 로그인 URL
+     * @return  (status) 200,
+     *          (body) 네이버 로그인 URL
      */
     @GetMapping("/login")
-    public ResponseEntity<Void> redirectToNaverAuth(){
+    public ResponseEntity<String> redirectToNaverAuth(){
         // CSRF 방지를 위해 CSRF 방지 토큰 생성
         String state= UUID.randomUUID().toString();
         String encodedState= URLEncoder.encode(state, StandardCharsets.UTF_8);
@@ -72,11 +73,8 @@ public class NaverOAuthController{
                 .append("&redirect_uri=").append(naverOauthRedirectUri)
                 .append("&state=").append(encodedState)
                 .toString();
-        headers.setLocation(URI.create(url));
 
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .headers(headers)
-                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(url);
     }
 
     /**
@@ -87,53 +85,66 @@ public class NaverOAuthController{
      * @param code 인증 코드
      * @param error 에러 코드
      * @param errorDescription 에러 메세지
-     * @return  (statue) 200,
-     *          (header) Access, Refresh 토큰
-     *          (body) 소셜 유저 정보
+     * @return  (statue) 302,
+     *          (header > Authorization) Access 토큰
+     *          (header > Set-Cookie) Refresh 토큰
+     *          (header > Location) 성공한 경우 -> moment 메인 페이지 URL
+     *          (header > Location) 에러난 경우 -> moment 500 에러 페이지 URL
      */
     @GetMapping("/callback")
     public ResponseEntity<Map<String, Object>> callback(@RequestParam(value = "state", required = true) String state,
                                                         @RequestParam(value = "code", required = false) String code,
                                                         @RequestParam(value = "error", required = false) String error,
                                                         @RequestParam(value = "error_description", required = false) String errorDescription){
-        // CSRF 토큰 확인
-        String metaData=stateService.getMetaData(state);
-        if(metaData==null || !metaData.equals(NAVER_STATE_METADATA)){
-            // state 값이 다르다면
-            throw new AccessDeniedException("유효하지 않은 요청입니다.");
+        try{
+            // CSRF 토큰 확인
+            String metaData=stateService.getMetaData(state);
+            if(metaData==null || !metaData.equals(NAVER_STATE_METADATA)){
+                // state 값이 다르다면
+                throw new AccessDeniedException("유효하지 않은 요청입니다.");
+            }
+
+            // 네이버 로그인 과정에서 문제가 발생했다면 예외 처리
+            if(error!=null){
+                log.error("네이버 로그인 실패 : "+errorDescription);
+                throw new OAuth2AuthenticationException("네이버 로그인에 실패했습니다.");
+            }
+
+            // 요청에 이미 사용된 CSRF 토큰을 삭제
+            stateService.delete(state);
+
+            // 유저 프로필 조회
+            UserProfileReadResponseDTO userProfileDTO=oAuthService.loginWithNaver(code, state);
+
+            // HTTP Header 설정
+            HttpHeaders headers=new HttpHeaders();
+
+            // Access 토큰 발급
+            String userId= userProfileDTO.getId();
+            String accessToken = jwtUtil.generateAccessToken(userId);
+            headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+            // Refresh 토큰 발급
+            ResponseCookie refreshTokenCookie= jwtUtil.generateRefreshCookie(userId);
+            headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+            // Location 설정
+            headers.add(HttpHeaders.LOCATION, momentMainUrl);
+
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .headers(headers)
+                    .build();
+        } catch(Exception e){
+            // 실패 했으면, 500 에러 페이지로 리다이렉트
+
+            // Location 설정
+            HttpHeaders headers=new HttpHeaders();
+            headers.add(HttpHeaders.LOCATION, moment500ErrorUrl);
+
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .headers(headers)
+                    .build();
         }
 
-        // 네이버 로그인 과정에서 문제가 발생했다면 예외 처리
-        if(error!=null){
-            log.error("네이버 로그인 실패 : "+errorDescription);
-            throw new OAuth2AuthenticationException("네이버 로그인에 실패했습니다.");
-        }
-
-        // 요청에 이미 사용된 CSRF 토큰을 삭제
-        stateService.delete(state);
-
-        // 유저 프로필 조회
-        UserProfileReadResponseDTO userProfileDTO=oAuthService.loginWithNaver(code, state);
-
-        // HTTP Header 설정
-        HttpHeaders headers=new HttpHeaders();
-
-        // Access 토큰 발급
-        String userId= userProfileDTO.getId();
-        String accessToken = jwtUtil.generateAccessToken(userId);
-        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-
-        // Refresh 토큰 발급
-        ResponseCookie refreshTokenCookie= jwtUtil.generateRefreshCookie(userId);
-        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        // HTTP Body 설정
-        ResponseMap responseMap=new ResponseMap();
-        responseMap.put("message", "네이버 로그인에 성공했습니다.");
-        responseMap.put("user", userProfileDTO);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .headers(headers)
-                .body(responseMap.getMap());
     }
 }

--- a/src/main/java/applesquare/moment/oauth/naver/service/impl/NaverAuthServiceImpl.java
+++ b/src/main/java/applesquare/moment/oauth/naver/service/impl/NaverAuthServiceImpl.java
@@ -23,10 +23,8 @@ public class NaverAuthServiceImpl implements NaverAuthService {
     private String naverClientId;
     @Value("${naver.client.secret}")
     private String naverClientSecret;
-    @Value("${naver.token.url}")
-    private String naverTokenUrl;
-    @Value("${naver.user.info.url}")
-    private String naverUserInfoUrl;
+    private final String naverTokenUrl="https://nid.naver.com/oauth2.0/token";
+    private final String naverUserInfoUrl="https://openapi.naver.com/v1/nid/me";
 
 
     /**


### PR DESCRIPTION
수정 사항 1 ) 카카오 로그인 API(GET /api/oauth/kakao/login)에서 원래는 302 코드와 함께 Location 헤더 설정해서 카카오 로그인 페이지로 리다이렉트 시키려고 했었습니다. API 테스트는 통과했는데, 프론트 테스트해보니까 CORS에서가 발생해서, 카카오 로그인 URL을 Body에 전달하기로 했습니다. (다른 도메인으로 리다이렉트 시키려고 해서 에러가 발생한 거 같습니다)

수정 사항 2 ) 카카오 로그인 콜백 API(GET /api/oauth/kakao/callback)에서 자동 회원가입이 성공한 이후, 브라우저가 /api/oauth/kakao/callback에 계속 머물게 되는 문제가 있어서, 서버 측에서 리다이렉트 하도록 수정했습니다. (소셜 로그인 성공 -> 메인 페이지로 리다이렉트,
소셜 로그인 실패 -> 에러 페이지로 리다이렉트)