### PR TITLE
[feat] PW 재설정 URL 변경

### DIFF
--- a/src/main/java/applesquare/moment/address/service/impl/KakaoAddressServiceImpl.java
+++ b/src/main/java/applesquare/moment/address/service/impl/KakaoAddressServiceImpl.java
@@ -20,7 +20,7 @@ public class KakaoAddressServiceImpl implements KakaoAddressService {
     private final RestTemplate restTemplate;
     @Value("${kakao.client.id}")
     private String kakaoClientId;
-    private final String kakaoAddressUrl="https://dapi.kakao.com/v2/local/search/address.json";
+    private final String KAKAO_ADDRESS_URL="https://dapi.kakao.com/v2/local/search/address.json";
 
 
     /**
@@ -36,7 +36,7 @@ public class KakaoAddressServiceImpl implements KakaoAddressService {
         Integer size = kakaoAddressSearchRequestDTO.getSize();
 
         // URL 생성
-        StringBuilder sb=new StringBuilder(kakaoAddressUrl).append("?query=").append(keyword);
+        StringBuilder sb=new StringBuilder(KAKAO_ADDRESS_URL).append("?query=").append(keyword);
         if (analyzeType!= null) sb.append("&analyze_type=").append(analyzeType);
         if (page != null) sb.append("&page=").append(page);
         if (size != null) sb.append("&size=").append(size);

--- a/src/main/java/applesquare/moment/auth/service/AuthService.java
+++ b/src/main/java/applesquare/moment/auth/service/AuthService.java
@@ -9,7 +9,7 @@ public interface AuthService {
     int MAX_PASSWORD_LENGTH=20;
 
     int PW_RESET_TOKEN_TTL_MINUTE=10;
-    String PW_RESET_URL="http://moment.com/reset-password";
+
 
     // 새로운 유저 생성 (회원가입)
     void createUser(UserCreateRequestDTO userCreateRequestDTO, String emailState);

--- a/src/main/java/applesquare/moment/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/applesquare/moment/auth/service/impl/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import applesquare.moment.user.service.UserInfoService;
 import applesquare.moment.util.StringUtil;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,9 @@ public class AuthServiceImpl implements AuthService {
     private final AddressService addressService;
     private final StateService stateService;
     private final EmailSendService emailSendService;
+
+    @Value("${moment.front.reset-password}")
+    private final String PW_RESET_URL;
 
 
     /**

--- a/src/main/java/applesquare/moment/location/service/impl/KakaoLocationServiceImpl.java
+++ b/src/main/java/applesquare/moment/location/service/impl/KakaoLocationServiceImpl.java
@@ -20,7 +20,7 @@ public class KakaoLocationServiceImpl implements KakaoLocationService {
     private final RestTemplate restTemplate;
     @Value("${kakao.client.id}")
     private String kakaoClientId;
-    private final String kakaoLocationUrl="https://dapi.kakao.com/v2/local/search/keyword.json";
+    private final String KAKAO_LOCATION_URL="https://dapi.kakao.com/v2/local/search/keyword.json";
 
 
     /**
@@ -35,7 +35,7 @@ public class KakaoLocationServiceImpl implements KakaoLocationService {
         Integer size = kakaoLocationSearchRequestDTO.getSize();
 
         // URL 생성
-        StringBuilder sb=new StringBuilder(kakaoLocationUrl).append("?query=").append(keyword);
+        StringBuilder sb=new StringBuilder(KAKAO_LOCATION_URL).append("?query=").append(keyword);
         if (page != null) sb.append("&page=").append(page);
         if (size != null) sb.append("&size=").append(size);
         String url = sb.toString();

--- a/src/main/java/applesquare/moment/oauth/kakao/controller/KakaoOAuthController.java
+++ b/src/main/java/applesquare/moment/oauth/kakao/controller/KakaoOAuthController.java
@@ -32,7 +32,7 @@ public class KakaoOAuthController {
     @Value("${moment.front.error.500.url}")
     private String moment500ErrorUrl;
 
-    private final String kakaoLoginUrl="https://kauth.kakao.com/oauth/authorize";
+    private final String KAKAO_LOGIN_URL="https://kauth.kakao.com/oauth/authorize";
 
 
     /**
@@ -45,7 +45,7 @@ public class KakaoOAuthController {
     @GetMapping("/login")
     public ResponseEntity<String> redirectToKakaoAuth(){
         // 카카오 로그인 화면으로 리다이렉트
-        String url = new StringBuilder(kakaoLoginUrl)
+        String url = new StringBuilder(KAKAO_LOGIN_URL)
                 .append("?client_id=").append(kakaoClientId)
                 .append("&redirect_uri=").append(kakaoOauthRedirectUri)
                 .append("&response_type=code")

--- a/src/main/java/applesquare/moment/oauth/kakao/service/impl/KakaoAuthServiceImpl.java
+++ b/src/main/java/applesquare/moment/oauth/kakao/service/impl/KakaoAuthServiceImpl.java
@@ -27,8 +27,8 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
     private String kakaoClientId;
     @Value("${kakao.oauth.redirect-uri}")
     private String kakaoOauthRedirectUri;
-    private final String kakaoTokenUrl="https://kauth.kakao.com/oauth/token";
-    private final String kakaoUserInfoUrl="https://kapi.kakao.com/v2/user/me";
+    private final String KAKAO_TOKEN_URL="https://kauth.kakao.com/oauth/token";
+    private final String KAKAO_USER_INFO_URL="https://kapi.kakao.com/v2/user/me";
 
 
     /**
@@ -52,7 +52,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
         // HTTP 요청 보내기
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest=new HttpEntity<>(body, headers);
         ResponseEntity<Map> kakaoTokenResponse = restTemplate.exchange(
-                kakaoTokenUrl,
+                KAKAO_TOKEN_URL,
                 HttpMethod.POST,
                 kakaoTokenRequest,
                 Map.class);
@@ -85,7 +85,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
         // HTTP 요청 보내기
         HttpEntity<String> kakaoUserRequest = new HttpEntity<>(headers);
         ResponseEntity<KakaoUserInfoReadResponseDTO> kakaoUserResponse = restTemplate.exchange(
-                kakaoUserInfoUrl,
+                KAKAO_USER_INFO_URL,
                 HttpMethod.GET,
                 kakaoUserRequest,
                 KakaoUserInfoReadResponseDTO.class

--- a/src/main/java/applesquare/moment/oauth/naver/controller/NaverOAuthController.java
+++ b/src/main/java/applesquare/moment/oauth/naver/controller/NaverOAuthController.java
@@ -43,7 +43,7 @@ public class NaverOAuthController{
     @Value("${moment.front.error.500.url}")
     private String moment500ErrorUrl;
 
-    private final String naverLoginUrl="https://nid.naver.com/oauth2.0/authorize";
+    private final String NAVER_LOGIN_URL="https://nid.naver.com/oauth2.0/authorize";
     private final String NAVER_STATE_METADATA="naver-login-redirect";
 
 
@@ -67,7 +67,7 @@ public class NaverOAuthController{
         HttpHeaders headers=new HttpHeaders();
 
         // 네이버 로그인 화면으로 리다이렉트
-        String url=new StringBuilder(naverLoginUrl)
+        String url=new StringBuilder(NAVER_LOGIN_URL)
                 .append("?response_type=code")
                 .append("&client_id=").append(naverClientId)
                 .append("&redirect_uri=").append(naverOauthRedirectUri)

--- a/src/main/java/applesquare/moment/oauth/naver/service/impl/NaverAuthServiceImpl.java
+++ b/src/main/java/applesquare/moment/oauth/naver/service/impl/NaverAuthServiceImpl.java
@@ -23,8 +23,8 @@ public class NaverAuthServiceImpl implements NaverAuthService {
     private String naverClientId;
     @Value("${naver.client.secret}")
     private String naverClientSecret;
-    private final String naverTokenUrl="https://nid.naver.com/oauth2.0/token";
-    private final String naverUserInfoUrl="https://openapi.naver.com/v1/nid/me";
+    private final String NAVER_TOKEN_URL="https://nid.naver.com/oauth2.0/token";
+    private final String NAVER_USER_INFO_URL="https://openapi.naver.com/v1/nid/me";
 
 
     /**
@@ -36,7 +36,7 @@ public class NaverAuthServiceImpl implements NaverAuthService {
     @Override
     public String getAccessToken(String code, String state){
         // URL 생성
-        String url=new StringBuilder(naverTokenUrl)
+        String url=new StringBuilder(NAVER_TOKEN_URL)
                 .append("?grant_type=authorization_code")
                 .append("&client_id=").append(naverClientId)
                 .append("&client_secret=").append(naverClientSecret)
@@ -85,7 +85,7 @@ public class NaverAuthServiceImpl implements NaverAuthService {
         headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
 
         // HTTP 요청 보내기
-        String url=naverUserInfoUrl;
+        String url=NAVER_USER_INFO_URL;
         HttpEntity<String> naverUserRequest=new HttpEntity<>(headers);
         ResponseEntity<NaverUserInfoReadResponseDTO> naverUserResponse=restTemplate.exchange(
                 url,


### PR DESCRIPTION
계정 찾기 API 결과 이메일로 보내지는 PW 재설정 URL을 임시 URL에서 프론트 서버 도메인을 이용한 URL로 변경했습니다.