### PR TITLE
[feat] 회원가입 정책 변경

### DIFF
--- a/src/main/java/applesquare/moment/auth/dto/UserCreateRequestDTO.java
+++ b/src/main/java/applesquare/moment/auth/dto/UserCreateRequestDTO.java
@@ -22,7 +22,7 @@ import java.time.LocalDate;
 public class UserCreateRequestDTO {
     @NotNull
     @Size(min= UserInfoService.MIN_NICKNAME_LENGTH, max=UserInfoService.MAX_NICKNAME_LENGTH)
-    @Pattern(regexp = Validator.NICKNAME_PATTERN, message = "한글, 알파벳 대소문자, 숫자, 밑줄 (_), 하이픈 (-)만 입력 가능합니다.")
+    @Pattern(regexp = Validator.NICKNAME_PATTERN, message = "한글, 알파벳 대소문자, 숫자, 밑줄 (_), 하이픈 (-), 연속 길이 1인 중간 공백( )만 입력 가능합니다.")
     private String nickname;
     @NotNull
     @Size(min= AuthService.MIN_USERNAME_LENGTH, max = AuthService.MAX_USERNAME_LENGTH)
@@ -34,7 +34,6 @@ public class UserCreateRequestDTO {
     private String password;
     private LocalDate birth;
     private Gender gender;
-    @NotNull
     @Email
     private String email;
     private String address;

--- a/src/main/java/applesquare/moment/auth/model/UserAccount.java
+++ b/src/main/java/applesquare/moment/auth/model/UserAccount.java
@@ -24,7 +24,7 @@ public class UserAccount extends BaseEntity {
     private String username;
     @Column(name = "password", nullable = false, updatable = true)
     private String password;
-    @Column(name = "email", nullable = false, updatable = true)
+    @Column(name = "email", nullable = true, updatable = true)
     private String email;
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name="user_info_id", nullable = false, updatable = false)

--- a/src/main/java/applesquare/moment/util/NicknameGenerator.java
+++ b/src/main/java/applesquare/moment/util/NicknameGenerator.java
@@ -27,6 +27,6 @@ public class NicknameGenerator {
     public static String generateNickname(){
         String first=FIRST_PART[random.nextInt(FIRST_PART.length)];
         String second=SECOND_PART[random.nextInt(SECOND_PART.length)];
-        return first+"_"+second;
+        return first+" "+second;
     }
 }

--- a/src/main/java/applesquare/moment/util/Validator.java
+++ b/src/main/java/applesquare/moment/util/Validator.java
@@ -8,7 +8,7 @@ import jakarta.validation.Validation;
 import java.util.Set;
 
 public class Validator {
-    public static final String NICKNAME_PATTERN="^[가-힣A-Za-z0-9_-]+$";
+    public static final String NICKNAME_PATTERN="^(?! )[가-힣A-Za-z0-9_-]+( [가-힣A-Za-z0-9_-]+)*(?<! )$";
     public static final String USERNAME_PATTERN="^[A-Za-z0-9_-]+$";
     public static final String PASSWORD_PATTERN="^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!\\?@#\\$%\\^&])[A-Za-z\\d!\\?@#\\$%\\^&]+$";
 


### PR DESCRIPTION
닉네임 : 공백 불가 -> "연속 길이 1인 중간 공백 허용"
이메일 : 필수 입력 -> "선택 입력"

닉네임은 공백으로 시작하거나, 공백으로 끝날 수 없습니다.
대신 글자 중간중간에 길이 1인 공백은 넣을 수 있습니다.

회원 가입 절차가 너무 길면, 사용자가 불편할 것 같아서, 이메일 등록 안 해도 회원가입 할 수 있도록 설정했습니다.